### PR TITLE
chore(ci): pin actions to commit SHAs to satisfy repo policy

### DIFF
--- a/.github/workflows/attest-documents.yml
+++ b/.github/workflows/attest-documents.yml
@@ -32,7 +32,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@8a7f5b0a4f97333e4e2e5c7a9d0a9f2a93b3c4bb
+        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
 
       - name: List important documents
         run: |
@@ -40,7 +40,7 @@ jobs:
           ls -la *.md *.html *.pdf *.json *.jsonc 2>/dev/null || echo "Algunos tipos no encontrados"
           
       - name: Attest branding documents
-        uses: actions/attest-build-provenance@be6ca6c8f6a39d5c7b13f2f1b746b2f9bda7b8b9
+        uses: actions/attest-build-provenance@ba965ac88abfc6fa49344893ed19e5bf479a07d6
         with:
           subject-path: |
             README.md
@@ -52,7 +52,7 @@ jobs:
             CONTRIBUTING.md
 
       - name: Attest additional files
-        uses: actions/attest-build-provenance@be6ca6c8f6a39d5c7b13f2f1b746b2f9bda7b8b9
+        uses: actions/attest-build-provenance@ba965ac88abfc6fa49344893ed19e5bf479a07d6
         if: always()
         with:
           subject-path: |


### PR DESCRIPTION
Repository policy: actions must be pinned to full commit SHAs.

- actions/checkout -> actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
- actions/attest-build-provenance -> actions/attest-build-provenance@ba965ac88abfc6fa49344893ed19e5bf479a07d6